### PR TITLE
trace/traceutil: introduce RoundTrip

### DIFF
--- a/traceutil/roundtrip.go
+++ b/traceutil/roundtrip.go
@@ -1,0 +1,191 @@
+package traceutil
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptrace"
+	"sync"
+	"time"
+)
+
+// RoundTripResult is a set of timestamps set at various stages of an outgoing
+// HTTP request intended to be passed to a FinishFunc passed in to RoundTrip.
+type RoundTripResult struct {
+	Started              time.Time
+	WroteHeaders         time.Time
+	WroteRequest         time.Time
+	GotFirstResponseByte time.Time
+	ReadHeaders          time.Time
+	ReadResponse         time.Time
+
+	BytesWritten int // TODO: implemenent
+	BytesRead    int
+
+	// The request traced. It is not safe to modify nor read from its body
+	// or headers.
+	Request *http.Request
+
+	// The response traced. It is not safe to modify nor read from its body
+	// of headers.  It is nil if no response was recieved.
+	Response *http.Response
+
+	Err error
+}
+
+func propagateHTTP(req *http.Request) {
+	// TODO: implement
+}
+
+type traceRoundTripper struct {
+	inner    http.RoundTripper
+	finished FinishFunc
+}
+
+// RoundTrip returns a http.RoundTripper that wraps inner for purposes of
+// recording timestamps to a RoundTripResult which is passed to finished on
+// completion or error of the returned http.RoundTripper.
+func RoundTrip(inner http.RoundTripper, finished FinishFunc) http.RoundTripper {
+	return traceRoundTripper{inner: inner, finished: finished}
+}
+
+type FinishFunc func(result *RoundTripResult)
+
+// FinishBasic records a single span for the request representing the from
+// first request byte written to last response byte read.
+func FinishBasic() FinishFunc {
+	panic("TODO")
+}
+
+// FinishDetail records sevaral detailed spans for the request representing the
+// from first request byte written to last response byte read.
+//
+// The spans are:
+//
+//    |==RoundTrip=======================================================|
+//    |==WroteHeader==                                                   |
+//    |               ==WroteBody==                                      |
+//    |                                  ==ReadFirstByte==               |
+//    |                                                   ==ReadHeaders==|
+//    |==================================================================|
+//
+func FinishDetail() FinishFunc {
+	panic("TODO")
+}
+
+func (r traceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var (
+		trace   = newClientTrace()
+		ctx     = httptrace.WithClientTrace(req.Context(), trace.client)
+		timeNow = timeNowFromContext(ctx)
+	)
+	req = req.WithContext(ctx)
+
+	// TODO(bmizerany): check if already configured for propagation as to
+	// not override anything custom? We could do this with a key in the
+	// req.Context.
+	propagateHTTP(req)
+
+	trace.Request = req
+	trace.Started = timeNow()
+
+	res, err := r.inner.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	trace.Response = res
+	trace.ReadHeaders = timeNow()
+
+	finish := func(err error) {
+		if trace.Err != nil {
+			trace.Err = err
+		}
+		trace.ReadResponse = timeNow()
+		if r.finished != nil {
+			// TODO: doc you don't own this after done
+			r.finished(trace.RoundTripResult)
+		}
+		clientTracePool.Put(trace)
+	}
+
+	res.Body = traceBody{
+		body:   res.Body,
+		result: trace.RoundTripResult,
+		finish: finish,
+	}
+	return res, nil
+}
+
+type traceBody struct {
+	body   io.ReadCloser
+	result *RoundTripResult
+	finish func(error)
+}
+
+func (t traceBody) Read(b []byte) (int, error) {
+	n, err := t.body.Read(b)
+	t.result.BytesRead += n
+	if err != nil {
+		if err == io.EOF {
+			err = nil
+		}
+		t.finish(err)
+	}
+	return n, err
+}
+
+func (t traceBody) Close() error {
+	err := t.body.Close()
+	t.finish(err)
+	return err
+}
+
+type clientTrace struct {
+	*RoundTripResult
+	client *httptrace.ClientTrace
+}
+
+var clientTracePool sync.Pool
+
+func newClientTrace() *clientTrace {
+	trace, ok := clientTracePool.Get().(*clientTrace)
+	if ok {
+		*trace.RoundTripResult = RoundTripResult{}
+		return trace
+	}
+
+	trace = &clientTrace{
+		RoundTripResult: new(RoundTripResult),
+	}
+
+	trace.client = &httptrace.ClientTrace{
+		GotFirstResponseByte: func() {
+			trace.GotFirstResponseByte = time.Now()
+		},
+		WroteHeaders: func() {
+			trace.WroteHeaders = time.Now()
+		},
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			trace.WroteRequest = time.Now()
+
+			// TODO: do something with info.Err?
+			//
+			// NOTE: BE CAREFUL - it can race with
+			// onErrBody since we may start reading the
+			// response before all of the request is
+			// written.
+		},
+	}
+	return trace
+}
+
+type timeNowKey struct{}
+
+func timeNowFromContext(ctx context.Context) func() time.Time {
+	v := ctx.Value(timeNowKey{})
+	if v != nil {
+		return v.(func() time.Time)
+	}
+	return time.Now
+}

--- a/traceutil/roundtrip_test.go
+++ b/traceutil/roundtrip_test.go
@@ -1,0 +1,83 @@
+package traceutil
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptrace"
+	"testing"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func BenchmarkRoundTrip(b *testing.B) {
+	b.Run("basic", func(b *testing.B) {
+		var (
+			body = ioutil.NopCloser(bytes.NewBuffer(nil))
+
+			innerRes = &http.Response{
+				StatusCode: 200,
+				Body:       body,
+			}
+
+			inner = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				// pretend to be the Transport
+				t := httptrace.ContextClientTrace(req.Context())
+				t.WroteHeaders()
+				t.WroteRequest(httptrace.WroteRequestInfo{})
+				t.GotFirstResponseByte()
+				return innerRes, nil
+			})
+		)
+
+		b.ReportAllocs()
+
+		r := RoundTrip(inner, nil)
+		for i := 0; i < b.N; i++ {
+			innerRes.Body = body
+
+			res, err := r.RoundTrip(new(http.Request))
+			if err != nil {
+				panic(err)
+			}
+			res.Body.Close()
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			var (
+				body = ioutil.NopCloser(bytes.NewBuffer(nil))
+
+				innerRes = &http.Response{
+					StatusCode: 200,
+					Body:       body,
+				}
+
+				inner = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					// pretend to be the Transport
+					t := httptrace.ContextClientTrace(req.Context())
+					t.WroteHeaders()
+					t.WroteRequest(httptrace.WroteRequestInfo{})
+					t.GotFirstResponseByte()
+					return innerRes, nil
+				})
+			)
+
+			r := RoundTrip(inner, nil)
+			for pb.Next() {
+				innerRes.Body = body
+
+				res, err := r.RoundTrip(new(http.Request))
+				if err != nil {
+					panic(err)
+				}
+				res.Body.Close()
+			}
+		})
+	})
+
+}


### PR DESCRIPTION
The purpose of this PR is to introduce/propose and discuss a new subpackage traceutil for housing various tracing utility functions for use with the trace package. It is intended that utility functions in this package be "boring" in that they are common patterns for tracing Go things.

The first of these "boring" utility function proposals is RoundTrip. RoundTrip wraps a http.RoundTripper with spans using the httptrace package and produces a result suitable for a FinishFunc of which there are two pre-made. One for a basic span, and another for detailed spans.

I'm very happy to discuss the design and further explain my motivation here if anyone has questions about anything that may be unclear.

-b